### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 
 This repository is meant for a multi-device network composed of embedded system platforms (Jetson Nano or Raspberry Pi), GPU Trainer Platforms, and Auxilary platforms (remote control and simulation). The repository also includes many ROS submodules. To clone please use the following command:
 ```
-git clone -b <PLATFORM BRANCH> --single-branch --recurse-submodules https://github.com/aborger/MARSHA
+git clone -b <PLATFORM BRANCH> --single-branch --recurse-submodules https://github.com/aborger/marsha
 ```
 Where <PLATFORM BRANCH> is the repository branch which represents the system you are cloning onto.


### PR DESCRIPTION
This change is to make sure the install.sh file completes running. This repo must be cloned as marsha rather than MARSHA so that the mv ~/marsha ~/catkin_ws/src command recognizes the cloned repo and moves it. I re-cloned using the git clone command here with this change and the install.sh file ran all the way through.